### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/8763b50e-148e-42d1-bd2c-6748089bccb6/dea592d0-4029-4c72-87b0-186444a90af0/_apis/work/boardbadge/bc0d7b46-399a-4d62-8f28-a48e994a1277)](https://dev.azure.com/aiw-devops/8763b50e-148e-42d1-bd2c-6748089bccb6/_boards/board/t/dea592d0-4029-4c72-87b0-186444a90af0/Microsoft.RequirementCategory)
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 Below you will find some information on how to perform common tasks.<br>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2177](https://dev.azure.com/aiw-devops/8763b50e-148e-42d1-bd2c-6748089bccb6/_workitems/edit/2177). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.